### PR TITLE
Improve rate limiting comments and naming

### DIFF
--- a/Http/Attributes/RateLimitAttribute.cs
+++ b/Http/Attributes/RateLimitAttribute.cs
@@ -1,30 +1,57 @@
-﻿using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using System.Collections.Concurrent;
 using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
 
 namespace Http.Attributes;
 
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+/// <summary>
+/// Atributo que limita la cantidad de solicitudes permitidas por usuario.
+/// </summary>
 public class RateLimitAttribute(int requestLimit = 20, int timeWindowSeconds = 60, int blockDurationSeconds = 60) : ActionFilterAttribute
 {
 
-    private static ConcurrentDictionary<string, RequestInfo> _requests = new();
-    private readonly int _requestLimit = requestLimit;
-    private readonly TimeSpan _timeWindow = TimeSpan.FromSeconds(timeWindowSeconds);
-    private readonly TimeSpan _blockDuration = TimeSpan.FromSeconds(blockDurationSeconds);
-    private readonly string key = Guid.NewGuid().ToString();
+    /// <summary>
+    /// Registro de solicitudes por identificador.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, RequestInfo> _requests = new();
 
+    /// <summary>
+    /// Límite máximo de solicitudes permitidas.
+    /// </summary>
+    private readonly int _requestLimit = requestLimit;
+
+    /// <summary>
+    /// Intervalo de tiempo para contar solicitudes.
+    /// </summary>
+    private readonly TimeSpan _timeWindow = TimeSpan.FromSeconds(timeWindowSeconds);
+
+    /// <summary>
+    /// Duración del bloqueo cuando se excede el límite.
+    /// </summary>
+    private readonly TimeSpan _blockDuration = TimeSpan.FromSeconds(blockDurationSeconds);
+
+    /// <summary>
+    /// Clave única para diferenciar instancias.
+    /// </summary>
+    private readonly string _key = Guid.NewGuid().ToString();
+
+    /// <summary>
+    /// Valida la frecuencia de solicitudes antes de ejecutar la acción.
+    /// </summary>
     public override void OnActionExecuting(ActionExecutingContext context)
     {
-
+        // Obtener el identificador primario del usuario a partir del token.
         var userId = GetPrimaryId(context.HttpContext.Request.Headers["token"].FirstOrDefault());
         var now = DateTime.UtcNow;
 
-        string cache = $"{key}-{userId}";
+        var cacheKey = $"{_key}-{userId}";
 
-        if (_requests.TryGetValue(cache, out RequestInfo? requestInfo))
+        if (_requests.TryGetValue(cacheKey, out RequestInfo? requestInfo))
         {
-            // Verificar si está bloqueado
+            // Verificar si el usuario está bloqueado.
             if (requestInfo.BlockedUntil.HasValue && requestInfo.BlockedUntil > now)
             {
                 // Respuesta.
@@ -33,7 +60,7 @@ public class RateLimitAttribute(int requestLimit = 20, int timeWindowSeconds = 6
                     Response = Responses.RateLimitExceeded,
                     Message = $"Has excedido el límite de solicitudes. Intenta nuevamente después de {requestInfo.BlockedUntil - now:hh\\:mm\\:ss}."
                 };
-                // Bloquear la solicitud con un código 429
+                // Bloquear la solicitud con un código 429.
                 context.Result = new ContentResult
                 {
                     Content = System.Text.Json.JsonSerializer.Serialize(response),
@@ -44,11 +71,11 @@ public class RateLimitAttribute(int requestLimit = 20, int timeWindowSeconds = 6
             }
             else if (requestInfo.BlockedUntil.HasValue && requestInfo.BlockedUntil <= now)
             {
-                // Si el tiempo de bloqueo ha pasado, reiniciar el contador
+                // Si el tiempo de bloqueo ha pasado, reiniciar el contador.
                 requestInfo.Reset(now);
             }
 
-            // Verificar si está dentro del intervalo de tiempo
+            // Verificar si está dentro del intervalo de tiempo.
             if (requestInfo.LastRequestTime.Add(_timeWindow) > now)
             {
                 requestInfo.RequestCount++;
@@ -61,7 +88,7 @@ public class RateLimitAttribute(int requestLimit = 20, int timeWindowSeconds = 6
                         Response = Responses.RateLimitExceeded,
                         Message = $"Has excedido el límite de solicitudes. Intenta nuevamente después de {requestInfo.BlockedUntil - now:hh\\:mm\\:ss}."
                     };
-                    // Bloquear al usuario
+                    // Bloquear al usuario.
                     requestInfo.BlockedUntil = now.Add(_blockDuration);
                     context.Result = new ContentResult
                     {
@@ -74,21 +101,21 @@ public class RateLimitAttribute(int requestLimit = 20, int timeWindowSeconds = 6
             }
             else
             {
-                // Reiniciar el contador si ha pasado el tiempo
+                // Reiniciar el contador si ha pasado el tiempo.
                 requestInfo.Reset(now);
             }
         }
         else
         {
-            // Primera solicitud del usuario
-            _requests.TryAdd(cache, new RequestInfo(now));
+            // Primera solicitud del usuario.
+            _requests.TryAdd(cacheKey, new RequestInfo(now));
         }
 
         base.OnActionExecuting(context);
     }
 
     /// <summary>
-    /// Obtener el primary id del token JWT.
+    /// Obtiene el identificador primario del token JWT.
     /// </summary>
     /// <param name="token">Token a validar.</param>
     private static string GetPrimaryId(string? token)
@@ -99,18 +126,19 @@ public class RateLimitAttribute(int requestLimit = 20, int timeWindowSeconds = 6
 
         try
         {
-            // Decodificar el JWT sin verificar la firma
+            // Decodificar el JWT sin verificar la firma.
             var handler = new JwtSecurityTokenHandler();
             var jsonToken = handler.ReadJwtToken(token);
             var payload = jsonToken.Payload;
 
-            // Obtener el primary id del payload
-            var primarySid = payload.FirstOrDefault(p => p.Key == "http://schemas.microsoft.com/ws/2008/06/identity/claims/primarysid").Value;
+            // Obtener el identificador principal del payload.
+            var primarySid = payload.FirstOrDefault(p => p.Key == ClaimTypes.PrimarySid).Value;
 
             return primarySid?.ToString() ?? "";
         }
         catch (Exception)
         {
+            // Ignorar errores de decodificación.
         }
         return "";
 
@@ -119,8 +147,19 @@ public class RateLimitAttribute(int requestLimit = 20, int timeWindowSeconds = 6
 
 internal class RequestInfo
 {
+    /// <summary>
+    /// Cantidad de solicitudes realizadas.
+    /// </summary>
     public int RequestCount { get; set; }
+
+    /// <summary>
+    /// Momento de la última solicitud.
+    /// </summary>
     public DateTime LastRequestTime { get; set; }
+
+    /// <summary>
+    /// Tiempo hasta el cual el usuario está bloqueado.
+    /// </summary>
     public DateTime? BlockedUntil { get; set; }
 
     public RequestInfo(DateTime requestTime)

--- a/Http/Extensions/HttpExtensions.cs
+++ b/Http/Extensions/HttpExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Http.Middlewares;
+using Http.Middlewares;
 using LIN.Access.Logger;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
@@ -56,13 +56,13 @@ public static class HttpExtensions
 
 
     /// <summary>
-    /// Usar rate token limit.
+    /// Habilita el middleware de limitación de solicitudes por token.
     /// </summary>
-    /// <param name="limit">Limite.</param>
-    /// <param name="time">Tiempo.</param>
+    /// <param name="limit">Límite máximo de solicitudes.</param>
+    /// <param name="time">Duración del intervalo de evaluación.</param>
     public static IApplicationBuilder UseRateTokenLimit(this IApplicationBuilder app, int limit, TimeSpan time)
     {
-        RateTokenLimitingMiddleware.TimeSpan = time;
+        RateTokenLimitingMiddleware.TimeWindow = time;
         RateTokenLimitingMiddleware.RequestLimit = limit;
         app.UseMiddleware<RateTokenLimitingMiddleware>();
         app.UseMiddleware<GatewayBasePathMiddleware>();


### PR DESCRIPTION
## Summary
- document RateTokenLimitingMiddleware in Spanish and rename interval property to `TimeWindow`
- add Spanish documentation and proper C# naming to RateLimitAttribute
- clarify rate limit extension method and match new middleware API

## Testing
- `dotnet build Http/Http.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a88d808180832286f6208835ddaf50